### PR TITLE
new node: R Dataset, Table

### DIFF
--- a/GENERATORS/SAMPLE_DATASETS/R_DATASET/R_DATASET.py
+++ b/GENERATORS/SAMPLE_DATASETS/R_DATASET/R_DATASET.py
@@ -1,0 +1,20 @@
+from flojoy import flojoy, DataContainer
+from rdatasets import data
+
+
+@flojoy
+def R_DATASET(dc_inputs: list[DataContainer], params: dict) -> DataContainer:
+    """
+    Retrieves a pandas DataFrame from rdatasets using the provided dataset_key parameter and returns it wrapped in a DataContainer.
+
+    Args:
+        dc_inputs (list[DataContainer]): A list of DataContainer objects, but not used in this function.
+        params (dict): A dictionary of parameters for this function.
+            dataset_key (str): The key used to retrieve the DataFrame.
+
+    Returns:
+        DataContainer: A DataContainer object containing the retrieved pandas DataFrame.
+    """
+    dataset_key = params["dataset_key"]
+    df = data(dataset_key)
+    return DataContainer(type="dataframe", m=df)

--- a/GENERATORS/SAMPLE_IMAGES/SKLEARN_IMAGE/SKLEARNIMAGE.py
+++ b/GENERATORS/SAMPLE_IMAGES/SKLEARN_IMAGE/SKLEARNIMAGE.py
@@ -4,8 +4,7 @@ from skimage import data
 
 @flojoy
 def SKLEARNIMAGE(dc_inputs, params):
-    """
-    Mode designed to load example images from scikit-image.
+    """Node designed to load example images from scikit-image.
 
     Examples can be found here:
     https://scikit-image.org/docs/stable/auto_examples/index.html

--- a/MANIFEST/r_dataset.manifest.yaml
+++ b/MANIFEST/r_dataset.manifest.yaml
@@ -1,0 +1,11 @@
+COMMAND:
+  - name: R Dataset
+    key: R_DATASET
+    type: SAMPLE_DATASET
+    parameters:
+      dataset_key:
+        type: string
+        default: iris
+    pip_dependencies:
+      - name: rdatasets
+        v: 0.1.0

--- a/MANIFEST/table_plotly.manifest.yaml
+++ b/MANIFEST/table_plotly.manifest.yaml
@@ -1,0 +1,4 @@
+COMMAND:
+  - name: Table
+    key: TABLE
+    type: PLOTLY_VISOR

--- a/VISUALIZERS/PLOTLY/TABLE/TABLE.py
+++ b/VISUALIZERS/PLOTLY/TABLE/TABLE.py
@@ -1,0 +1,32 @@
+from flojoy import flojoy, DataContainer
+import plotly.graph_objects as go
+
+
+@flojoy
+def TABLE(dc_inputs: list[DataContainer], params: dict):
+    """Node creates a Plotly table visualization for a given input data container.
+
+    Args:
+    dc_inputs (list): A list of DataContainer object(s) containing the input data.
+    params (dict): A dictionary containing the parameters needed for the visualization.
+
+    Returns:
+    DataContainer: A DataContainer object containing the generated visualization and the processed data.
+
+    Raises:
+    ValueError: If the input data container is not supported.
+    """
+    dc_input = dc_inputs[0]
+    if dc_input.type in ["dataframe", "plotly"]:
+        df = dc_input.m
+        fig = go.Figure(
+            data=[
+                go.Table(
+                    header=dict(values=list(df.columns)),
+                    cells=dict(values=[df[col] for col in df.columns]),
+                )
+            ]
+        )
+        return DataContainer(type="plotly", fig=fig, m=df)
+    else:
+        raise ValueError("unsupported input type for Plotly TABLE node")


### PR DESCRIPTION
### Description

#### R_DATASETS
Retrieves a pandas DataFrame from `rdatasets` using the provided dataset_key parameter and returns it wrapped in a DataContainer.
#### TABLE
creates a Plotly table visualization for a given input `DataContainer` class of type 'dataframe'.
### Inputs & Outputs
#### R_DATASETS
Takes only one input named `dataset_key` which is the name of the dataset to retrieve from `rdatasets`. The default is 'iris'.

### Example APPS
https://github.com/flojoy-io/apps/pull/8
### Integrating the Node
#### R_DATASET
- Click on `+ Add Node` button in the SCRIPT tab.
- Expand 'Generators'
- Expand 'Sample datasets'
- Click on 'R Dataset' to add this node to the flow chart

#### TABLE
- Click on `+ Add Node` button in the SCRIPT tab.
- Expand 'Visualizers'
- Expand 'Plotly'
- Click on 'Table' to add this node to the flow chart

closes #27 
Corresponding PR in studio: https://github.com/flojoy-io/studio/pull/370