### PR TITLE
new node: Plotly Dataset

### DIFF
--- a/GENERATORS/SAMPLE_DATASETS/PLOTLY_DATASET/PLOTLY_DATASET.py
+++ b/GENERATORS/SAMPLE_DATASETS/PLOTLY_DATASET/PLOTLY_DATASET.py
@@ -1,0 +1,10 @@
+from flojoy import flojoy, DataContainer
+from plotly.express import data
+
+
+@flojoy
+def PLOTLY_DATASET(dc_inputs: list[DataContainer], params: dict) -> DataContainer:
+    dataset_key = params["dataset_key"]
+    df = getattr(data, dataset_key)()
+
+    return DataContainer(type="dataframe", m=df)

--- a/MANIFEST/plotly_dataset.manifest.yaml
+++ b/MANIFEST/plotly_dataset.manifest.yaml
@@ -1,0 +1,19 @@
+COMMAND:
+  - name: Plotly Dataset
+    key: PLOTLY_DATASET
+    type: SAMPLE_DATASET
+    parameters:
+      dataset_key:
+        type: select
+        options:
+          - wind
+          - iris
+          - carshare
+          - tips
+          - election
+          - experiment
+          - gapminder
+          - medals_long
+          - medals_wide
+          - stocks
+        default: wind


### PR DESCRIPTION
### Description
Retrieves a pandas DataFrame from plotly sample datasets using the provided dataset_key parameter and returns it wrapped in a DataContainer.

### Inputs & Outputs

Takes only one input named `dataset_key` which is the name of the dataset to retrieve from plotly sample datasets. The default is 'wind'.

### Example APPS
https://github.com/flojoy-io/apps/pull/9

### Integrating the Node
- Click on `+ Add Node` button in the SCRIPT tab.
- Expand 'Generators'
- Expand 'Sample datasets'
- Click on 'Plotly Dataset' to add this node to the flow chart

closes #28  
Corresponding PR in studio: https://github.com/flojoy-io/studio/pull/375