### PR TITLE
update plotly viz nodes to accept dataframe

### DIFF
--- a/VISUALIZERS/PLOTLY/BAR/BAR.py
+++ b/VISUALIZERS/PLOTLY/BAR/BAR.py
@@ -1,17 +1,35 @@
 from flojoy import flojoy, DataContainer
-import plotly.express as px
+import plotly.graph_objects as go
+import pandas as pd
 
 
 @flojoy
-def BAR(v, params):
-    dc_input = v[0]
-    if dc_input.type == "ordered_pair":
-        x = dc_input.x
-        if isinstance(dc_input.x, dict):
-            dict_keys = list(dc_input.x.keys())
-            x = dc_input.x[dict_keys[0]]
-        y = dc_input.y
-    else:
-        raise ValueError("unsupported input type for BAR node")
-    fig = px.scatter(x=x, y=y)
-    return DataContainer(type="plotly", fig=fig, x=x, y=y)
+def BAR(dc_inputs: list[DataContainer], params: dict) -> DataContainer:
+    """Node creates a Plotly Bar visualization for a given input data container."""
+    dc_input = dc_inputs[0]
+    fig = go.Figure()
+    match dc_input.type:
+        case "ordered_pair":
+            x = dc_input.x
+            if isinstance(dc_input.x, dict):
+                dict_keys = list(dc_input.x.keys())
+                x = dc_input.x[dict_keys[0]]
+            y = dc_input.y
+            fig.add_trace(go.Bar(x=x, y=y))
+        case "dataframe":
+            df = pd.DataFrame(dc_input.m)
+            for col in df.columns:
+                if df[col].dtype == "object":
+                    counts = df[col].value_counts()
+                    fig.add_trace(
+                        go.Bar(x=counts.index.tolist(), y=counts.tolist(), name=col)
+                    )
+                else:
+                    fig.add_trace(go.Bar(x=df.index, y=df[col], name=col))
+            fig.update_layout(
+                title="Bar Plot", xaxis_title="X Axis", yaxis_title="Y Axis"
+            )
+        case _:
+            raise ValueError("unsupported DataContainer type for BAR node")
+
+    return DataContainer(type="plotly", fig=fig)

--- a/VISUALIZERS/PLOTLY/HISTOGRAM/HISTOGRAM.py
+++ b/VISUALIZERS/PLOTLY/HISTOGRAM/HISTOGRAM.py
@@ -1,17 +1,29 @@
 from flojoy import flojoy, DataContainer
-import plotly.express as px
+import plotly.graph_objects as go
+import pandas as pd
 
 
 @flojoy
-def HISTOGRAM(v, params):
-    dc_input = v[0]
-    if dc_input.type == "ordered_pair":
-        x = dc_input.x
-        if isinstance(dc_input.x, dict):
-            dict_keys = list(dc_input.x.keys())
-            x = dc_input.x[dict_keys[0]]
-        y = dc_input.y
-    else:
-        raise ValueError("unsupported type for HISTOGRAM  node")
-    fig = px.histogram(x=x, y=y)
-    return DataContainer(type="plotly", fig=fig, x=x, y=y)
+def HISTOGRAM(dc_inputs: list[DataContainer], params: dict):
+    """Node creates a Plotly Histogram visualization for a given input data container."""
+    dc_input = dc_inputs[0]
+    fig = go.Figure()
+    match dc_input.type:
+        case "ordered_pair":
+            x = dc_input.x
+            if isinstance(dc_input.x, dict):
+                dict_keys = list(dc_input.x.keys())
+                x = dc_input.x[dict_keys[0]]
+            y = dc_input.y
+            fig.add_trace(go.Histogram(x=x, y=y))
+        case "dataframe":
+            df = pd.DataFrame(dc_input.m)
+            for col in df.columns:
+                fig.add_trace(go.Histogram(x=df[col], name=col))
+            fig.update_layout(
+                title="Histogram Plot", xaxis_title="Value", yaxis_title="Frequency"
+            )
+        case _:
+            raise ValueError("unsupported DataContainer type for HISTOGRAM node")
+
+    return DataContainer(type="plotly", fig=fig)

--- a/VISUALIZERS/PLOTLY/LINE/LINE.py
+++ b/VISUALIZERS/PLOTLY/LINE/LINE.py
@@ -1,17 +1,28 @@
 from flojoy import flojoy, DataContainer
 import plotly.graph_objects as go
+import pandas as pd
 
 
 @flojoy
-def LINE(v, params):
-    dc_input = v[0]
-    if dc_input.type == "ordered_pair":
-        x = dc_input.x
-        if isinstance(dc_input.x, dict):
-            dict_keys = list(dc_input.x.keys())
-            x = dc_input.x[dict_keys[0]]
-        y = dc_input.y
-    else:
-        raise ValueError("unsupported input type for LINE node")
-    fig = go.Figure(data=go.Line(x=x, y=y, mode="markers"))
-    return DataContainer(type="plotly", fig=fig, x=x, y=y)
+def LINE(dc_inputs: list[DataContainer], params: dict) -> DataContainer:
+    """Node creates a Plotly Line visualization for a given input data container."""
+    dc_input = dc_inputs[0]
+    fig = go.Figure()
+    match dc_input.type:
+        case "ordered_pair":
+            x = dc_input.x
+            if isinstance(dc_input.x, dict):
+                dict_keys = list(dc_input.x.keys())
+                x = dc_input.x[dict_keys[0]]
+            y = dc_input.y
+            fig.add_trace(go.Line(x=x, y=y, mode="lines"))
+        case "dataframe":
+            df = pd.DataFrame(dc_input.m)
+            for col in df.columns:
+                fig.add_trace(go.Scatter(x=df.index, y=df[col], mode="lines", name=col))
+                fig.update_layout(
+                    title="Line Plot", xaxis_title="X Axis", yaxis_title="Y Axis"
+                )
+        case _:
+            raise ValueError("unsupported DataContainer type for LINE node")
+    return DataContainer(type="plotly", fig=fig)

--- a/VISUALIZERS/PLOTLY/SCATTER/SCATTER.py
+++ b/VISUALIZERS/PLOTLY/SCATTER/SCATTER.py
@@ -1,17 +1,30 @@
 import plotly.graph_objects as go
 from flojoy import flojoy, DataContainer
+import pandas as pd
 
 
 @flojoy
-def SCATTER(v, params):
-    dc_input = v[0]
-    if dc_input.type == "ordered_pair":
-        x = dc_input.x
-        if isinstance(dc_input.x, dict):
-            dict_keys = list(dc_input.x.keys())
-            x = dc_input.x[dict_keys[0]]
-        y = dc_input.y
-    else:
-        raise ValueError("unsupported input type for SCATTER node")
-    fig = go.Figure(data=go.Scatter(x=x, y=y, mode="markers"))
-    return DataContainer(type="plotly", fig=fig, x=x, y=y)
+def SCATTER(dc_inputs: list[DataContainer], params: dict) -> DataContainer:
+    """Node creates a Plotly Scatter visualization for a given input data container."""
+    dc_input = dc_inputs[0]
+    fig = go.Figure()
+    match dc_input.type:
+        case "ordered_pair":
+            x = dc_input.x
+            if isinstance(dc_input.x, dict):
+                dict_keys = list(dc_input.x.keys())
+                x = dc_input.x[dict_keys[0]]
+            y = dc_input.y
+            fig.add_trace(go.Scatter(x=x, y=y, mode="markers"))
+        case "dataframe":
+            df = pd.DataFrame(dc_input.m)
+            for col in df.columns:
+                fig.add_trace(
+                    go.Scatter(x=df[col], y=df.index, mode="markers", name=col)
+                )
+            fig.update_layout(
+                title="Scatter Plot", xaxis_title="X Axis", yaxis_title="Y Axis"
+            )
+        case _:
+            raise ValueError("unsupported DataContainer type for SCATTER node")
+    return DataContainer(type="plotly", fig=fig)

--- a/VISUALIZERS/PLOTLY/TABLE/TABLE.py
+++ b/VISUALIZERS/PLOTLY/TABLE/TABLE.py
@@ -1,5 +1,6 @@
 from flojoy import flojoy, DataContainer
 import plotly.graph_objects as go
+import pandas as pd
 
 
 @flojoy
@@ -18,15 +19,15 @@ def TABLE(dc_inputs: list[DataContainer], params: dict):
     """
     dc_input = dc_inputs[0]
     if dc_input.type in ["dataframe", "plotly"]:
-        df = dc_input.m
+        df = pd.DataFrame(dc_input.m)
         fig = go.Figure(
             data=[
                 go.Table(
-                    header=dict(values=list(df.columns)),
-                    cells=dict(values=[df[col] for col in df.columns]),
+                    header=dict(values=list(df.columns), align="left"),
+                    cells=dict(values=[df[col] for col in df.columns], align="left"),
                 )
             ]
         )
         return DataContainer(type="plotly", fig=fig, m=df)
     else:
-        raise ValueError("unsupported input type for Plotly TABLE node")
+        raise ValueError("unsupported DataContainer type for Plotly TABLE node")


### PR DESCRIPTION
Updated plot visual nodes to accept `dataframe` type of `DataContainer` class.

corresponding studio PR: https://github.com/flojoy-io/studio/pull/376