### PR TITLE
Reorganizing serial nodes

### DIFF
--- a/INSTRUMENTS/Serial/Serial_timeseries/SERIAL_TIMESERIES.py
+++ b/INSTRUMENTS/Serial/Serial_timeseries/SERIAL_TIMESERIES.py
@@ -7,7 +7,7 @@ import plotly.graph_objects as go
 
 
 @flojoy
-def SERIAL(dc_inputs, params):
+def SERIAL_TIMESERIES(dc_inputs, params):
     """
     Node to take simple time dependent 1d data from an Ardunio,
     or a similar serial device.
@@ -40,7 +40,7 @@ def SERIAL(dc_inputs, params):
 
     num_readings * record_period is roughly the run length in seconds.
     """
-    print("parameters passed to SERIAL: ", params)
+    print("parameters passed to SERIAL_TIMESERIES: ", params)
     COM_PORT = params.get("com_port", "/dev/ttyUSB0")
     BAUD = int(params.get("BAUD_RATE", 9600))
     NUM = int(params.get("num_readings", 100))

--- a/MANIFEST/serial_timeseries.manifest.yaml
+++ b/MANIFEST/serial_timeseries.manifest.yaml
@@ -1,6 +1,6 @@
 COMMAND:
-  - name: SERIAL
-    key: SERIAL
+  - name: SERIAL_TIMESERIES
+    key: SERIAL_TIMESERIES
     type: SERIAL
     parameters:
       comport:


### PR DESCRIPTION
### Description

Reorganizing serial nodes to allow for multiple serial nodes. Renaming serial to serial_timeseries.

### Inputs & Outputs

No inputs. Time series outputs with multiple columns of y data possible

### Example APPS

https://github.com/flojoy-io/apps/pull/10

### Integrating the Node

Already integrated. Renaming the node to allow for more serial nodes.
