### PR TITLE
Add single measurement node

### DIFF
--- a/INSTRUMENTS/Serial/Serial_timeseries/SERIAL_SINGLE_MEAUREMENT.py
+++ b/INSTRUMENTS/Serial/Serial_timeseries/SERIAL_SINGLE_MEAUREMENT.py
@@ -1,0 +1,69 @@
+from flojoy import flojoy, DataContainer
+from time import sleep
+import serial
+import numpy as np
+from datetime import datetime
+import plotly.graph_objects as go
+
+
+@flojoy
+def SERIAL_SINGLE_MEASUREMENT(dc_inputs, params):
+    """
+    Node to take a single reading of data from an Ardunio,
+    or a similar serial device.
+    For example you can record temperature following this tutorial:
+
+    https://learn.adafruit.com/thermistor/using-a-thermistor
+
+    with Serial.println(steinhart) as the only line printing.
+
+    It is important that the last line Arduino is returning is the
+    data with a new line at the end (i.e. println()).
+
+    The other lines must be returned with print()
+    with print(",") between each line.
+
+    For example:
+
+    print(reading0)
+    print(",")
+    println(reading1)
+
+    If there is more than one column, the SELECT_ARRAY node must be
+    used after this node.
+
+    params:
+    BAUD_RATE: Baud rate for the serial device.
+    com_port: COM port of the serial device
+    """
+    print("parameters passed to SERIAL_TIMESERIES: ", params)
+    COM_PORT = params["comport"]
+    BAUD = int(params["baudrate"])
+
+    ser = serial.Serial(COM_PORT, timeout=1, baudrate=BAUD)
+    # The first reading is commonly empty.
+    s = ser.readline().decode()
+
+    # Some readings may be empty. Try a second time if so.
+    if s != "":
+        reading = s[:-2].split(",")
+    else:
+        s = ser.readline().decode()
+        reading = s[:-2].split(",")
+
+    reading = np.array(reading)
+    reading = reading.astype("float64")
+
+    data = go.Line(x=[0], y=[0], mode="markers")
+    fig = go.Figure(data=data)
+    return DataContainer(type="plotly", fig=fig, x=[0], y=reading)
+
+
+@flojoy
+def SERIAL_SINGLE_MEASUREMENT_MOCK(dc, params):
+    print("Running mock version of Serial")
+
+    x = np.linspace(0, 100, 100)
+    y = np.linspace(0, 100, 100)
+
+    return DataContainer(x=x, y=y)

--- a/MANIFEST/serial_single_measurement.manifest.yaml
+++ b/MANIFEST/serial_single_measurement.manifest.yaml
@@ -1,0 +1,14 @@
+COMMAND:
+  - name: SERIAL_SINGLE_MEASUREMENT
+    key: SERIAL_SINGLE_MEASUREMENT
+    type: SERIAL
+    parameters:
+      comport:
+        type: string
+        default: "/dev/ttyUSB0"
+      baudrate:
+        type: float
+        default: 9600
+    pip_dependencies:
+      - name: pyserial
+        v: 3.5


### PR DESCRIPTION
Description
SERIAL_SINGLE_MEASUREMENT takes a single reading from a serial device (one or multiple columns).

Inputs & Outputs
No input. y outputs a numpy array for >1 data columns or a list for 1 column.

Example APPS
None yet. Works with SERIAL_TIMESERIES app if replacing SERIAL_TIMESERIES nodes.

Integrating the Node
Similar to SERIAL_TIMESERIES, the SELECT_COLUMN node must be used if there are multiple data columns (e.g. temperature and pressure).
