### PR TITLE
use `pd.util.testing` until flojoy requires pandas 2.X

### DIFF
--- a/GENERATORS/SIMULATIONS/TIMESERIES/TIMESERIES.py
+++ b/GENERATORS/SIMULATIONS/TIMESERIES/TIMESERIES.py
@@ -12,7 +12,7 @@ def TIMESERIES(dc_inputs: list[DataContainer], params: dict) -> DataContainer:
 
     try:
         np.random.seed(1)
-        testing.N, testing.K = 1000, 1  # rows, columns
+        pd.util.testing.N, pd.util.testing.K = 1000, 1  # rows, columns
         df = pd.util.testing.makeTimeDataFrame(freq="MS")
         return DataContainer(x=df.index.to_numpy(), y=df["A"].to_numpy())
     except Exception as e:


### PR DESCRIPTION
pd.testing is only available in pandas 2.X. Until flojoy marks that as a dependency, use `pd.util.testing`

### Description

- [x] I've included a concise description of what each node does

### Styleguide

- [x] My node adheres to the [styleguide](https://github.com/flojoy-io/nodes/blob/main/node_styleguide.md) for Flojoy nodes

### Docs

- [ ] I've submitted a PR for a documentation page for the new node(s) that contains usage examples (see docs.flojoy.io)

