### PR TITLE
Removes a redundant ABS node

### DIFF
--- a/ARITHMETIC/ABS.py
+++ b/ARITHMETIC/ABS.py
@@ -1,8 +1,0 @@
-import numpy as np
-from flojoy import flojoy, DataContainer
-
-
-@flojoy
-def ABS(v, params):
-    """Returns abolute value"""
-    return DataContainer(x=v[0].y, y=np.abs(v[0].y))

--- a/ARITHMETIC/__init__.py
+++ b/ARITHMETIC/__init__.py
@@ -1,1 +1,0 @@
-__all__ = ["ADD", "MULTIPLY", "SUBTRACT", "ABS"]


### PR DESCRIPTION
### Description

This node is redundant given what's in the https://github.com/flojoy-io/nodes/tree/main/TRANSFORMERS/ARITHMETIC directory already. 

- [ ] I've included a concise description of what each node does

### Styleguide

- [ ] My node adheres to the [styleguide](https://github.com/flojoy-io/nodes/blob/main/node_styleguide.md) for Flojoy nodes

### Docs

- [ ] I've submitted a PR for a documentation page for the new node(s) that contains usage examples (see docs.flojoy.io)

