### PR TITLE
add NLP_CONNECT_VIT_GPT2 node

### DIFF
--- a/AI_ML/IMAGE_CAPTIONING/NLP_CONNECT_VIT_GPT2/NLP_CONNECT_VIT_GPT2.py
+++ b/AI_ML/IMAGE_CAPTIONING/NLP_CONNECT_VIT_GPT2/NLP_CONNECT_VIT_GPT2.py
@@ -1,0 +1,47 @@
+from flojoy import flojoy, DataContainer
+from flojoy.hflib.hub_models import HubModelFactory, ImageCaptionModels
+
+import torchvision.transforms.functional as TF
+import numpy as np
+import pandas as pd
+
+
+@flojoy
+def NLP_CONNECT_VIT_GPT2(
+    dc_inputs: list[DataContainer], params: dict
+) -> DataContainer:
+    """The NLP_CONNECT_VIT_GPT2 node captions an input image and produces an output string wrapped
+    in a dataframe.
+
+    Parameters
+    ----------
+
+    Returns:
+    --------
+    DataContainer:
+        type 'dataframe' containing the caption column, and a single row.
+
+    """
+
+    input_image = dc_inputs[0]
+
+    if dc_inputs[0].type != "image":
+        raise ValueError(f"One of the supplied input objects is not of type 'image'")
+
+    r, g, b, a = input_image.r, input_image.g, input_image.b, input_image.a
+    nparray = (
+        np.stack((r, g, b, a), axis=2) if a is not None else np.stack((r, g, b), axis=2)
+    )
+    image = TF.to_pil_image(nparray).convert("RGB")
+
+    hub_model = HubModelFactory.create_model(ImageCaptionModels.NLP_CONNECT_VIT_GPT2)
+    hub_model.download_and_cache()
+    model, feature_extractor, tokenizer = hub_model.get_executable_model()
+    pixel_values = feature_extractor(images=[image], return_tensors="pt").pixel_values
+    output_ids = model.generate(pixel_values, max_length=16, num_beams=4)
+    preds = tokenizer.batch_decode(output_ids, skip_special_tokens=True)
+    pred = preds[0].strip()
+
+    df_pred = pd.DataFrame.from_records([(pred,)], columns=["caption"])
+
+    return DataContainer(type="dataframe", m=df_pred)

--- a/AI_ML/IMAGE_CAPTIONING/NLP_CONNECT_VIT_GPT2/NLP_CONNECT_VIT_GPT2.py
+++ b/AI_ML/IMAGE_CAPTIONING/NLP_CONNECT_VIT_GPT2/NLP_CONNECT_VIT_GPT2.py
@@ -23,10 +23,11 @@ def NLP_CONNECT_VIT_GPT2(
 
     """
 
-    input_image = dc_inputs[0]
 
-    if dc_inputs[0].type != "image":
-        raise ValueError(f"One of the supplied input objects is not of type 'image'")
+    if len(dc_inputs) != 1 or dc_inputs[0].type != "image":
+        raise ValueError(f"Invalid input, expected exactly one DataContainer of type 'image'")
+
+    input_image = dc_inputs[0]
 
     r, g, b, a = input_image.r, input_image.g, input_image.b, input_image.a
     nparray = (

--- a/AI_ML/IMAGE_CAPTIONING/NLP_CONNECT_VIT_GPT2/NLP_CONNECT_VIT_GPT2.py
+++ b/AI_ML/IMAGE_CAPTIONING/NLP_CONNECT_VIT_GPT2/NLP_CONNECT_VIT_GPT2.py
@@ -7,9 +7,7 @@ import pandas as pd
 
 
 @flojoy
-def NLP_CONNECT_VIT_GPT2(
-    dc_inputs: list[DataContainer], params: dict
-) -> DataContainer:
+def NLP_CONNECT_VIT_GPT2(dc_inputs: list[DataContainer], params: dict) -> DataContainer:
     """The NLP_CONNECT_VIT_GPT2 node captions an input image and produces an output string wrapped
     in a dataframe.
 
@@ -23,9 +21,10 @@ def NLP_CONNECT_VIT_GPT2(
 
     """
 
-
     if len(dc_inputs) != 1 or dc_inputs[0].type != "image":
-        raise ValueError(f"Invalid input, expected exactly one DataContainer of type 'image'")
+        raise ValueError(
+            f"Invalid input, expected exactly one DataContainer of type 'image'"
+        )
 
     input_image = dc_inputs[0]
 

--- a/AI_ML/IMAGE_CAPTIONING/NLP_CONNECT_VIT_GPT2/app.txt
+++ b/AI_ML/IMAGE_CAPTIONING/NLP_CONNECT_VIT_GPT2/app.txt
@@ -1,0 +1,139 @@
+{
+    "rfInstance": {
+        "nodes": [
+            {
+                "width": 150,
+                "height": 150,
+                "id": "NLP_CONNECT_VIT_GPT2-223c75c1-60d9-40ba-8d59-70585afb0aa6",
+                "type": "IMAGE_CAPTION",
+                "data": {
+                    "id": "NLP_CONNECT_VIT_GPT2-223c75c1-60d9-40ba-8d59-70585afb0aa6",
+                    "label": "NLP CONNECT VIT GPT2",
+                    "func": "NLP_CONNECT_VIT_GPT2",
+                    "type": "IMAGE_CAPTION",
+                    "ctrls": {},
+                    "selected": false
+                },
+                "position": {
+                    "x": 759.6279246626107,
+                    "y": 281.68121031230993
+                },
+                "selected": false,
+                "positionAbsolute": {
+                    "x": 759.6279246626107,
+                    "y": 281.68121031230993
+                },
+                "dragging": true
+            },
+            {
+                "width": 150,
+                "height": 150,
+                "id": "LOCAL_FILE-c59f3e5d-01ac-40d6-990a-d682f3cd3b15",
+                "type": "LOCAL_FILE_SYSTEM",
+                "data": {
+                    "id": "LOCAL_FILE-c59f3e5d-01ac-40d6-990a-d682f3cd3b15",
+                    "label": "LOCAL FILE",
+                    "func": "LOCAL_FILE",
+                    "type": "LOCAL_FILE_SYSTEM",
+                    "ctrls": {
+                        "file_type": {
+                            "functionName": "LOCAL_FILE",
+                            "param": "file_type",
+                            "value": "image"
+                        },
+                        "path": {
+                            "functionName": "LOCAL_FILE",
+                            "param": "path",
+                            "value": ""
+                        }
+                    },
+                    "pip_dependencies": [
+                        {
+                            "name": "xlrd",
+                            "v": "2.0.1"
+                        },
+                        {
+                            "name": "lxml",
+                            "v": "4.9.2"
+                        }
+                    ],
+                    "selected": false
+                },
+                "position": {
+                    "x": 321.056496091182,
+                    "y": 200.25263888373848
+                },
+                "selected": false,
+                "positionAbsolute": {
+                    "x": 321.056496091182,
+                    "y": 200.25263888373848
+                },
+                "dragging": true
+            },
+            {
+                "width": 210,
+                "height": 130,
+                "id": "END-0c3d9525-acc7-42f1-bffb-76d4f74dca2a",
+                "type": "TERMINATOR",
+                "data": {
+                    "id": "END-0c3d9525-acc7-42f1-bffb-76d4f74dca2a",
+                    "label": "END",
+                    "func": "END",
+                    "type": "TERMINATOR",
+                    "ctrls": {},
+                    "selected": false
+                },
+                "position": {
+                    "x": 1308.1993532340393,
+                    "y": 294.53835316945276
+                },
+                "selected": false,
+                "positionAbsolute": {
+                    "x": 1308.1993532340393,
+                    "y": 294.53835316945276
+                },
+                "dragging": true
+            }
+        ],
+        "edges": [
+            {
+                "source": "LOCAL_FILE-c59f3e5d-01ac-40d6-990a-d682f3cd3b15",
+                "sourceHandle": "main",
+                "target": "NLP_CONNECT_VIT_GPT2-223c75c1-60d9-40ba-8d59-70585afb0aa6",
+                "targetHandle": "NLP_CONNECT_VIT_GPT2",
+                "id": "reactflow__edge-LOCAL_FILE-c59f3e5d-01ac-40d6-990a-d682f3cd3b15main-NLP_CONNECT_VIT_GPT2-223c75c1-60d9-40ba-8d59-70585afb0aa6NLP_CONNECT_VIT_GPT2"
+            },
+            {
+                "source": "NLP_CONNECT_VIT_GPT2-223c75c1-60d9-40ba-8d59-70585afb0aa6",
+                "sourceHandle": "main",
+                "target": "END-0c3d9525-acc7-42f1-bffb-76d4f74dca2a",
+                "targetHandle": "END",
+                "id": "reactflow__edge-NLP_CONNECT_VIT_GPT2-223c75c1-60d9-40ba-8d59-70585afb0aa6main-END-0c3d9525-acc7-42f1-bffb-76d4f74dca2aEND"
+            }
+        ],
+        "viewport": {
+            "x": 211.62910019568181,
+            "y": 433.27994096381553,
+            "zoom": 0.6398461079234518
+        }
+    },
+    "ctrlsManifest": [
+        {
+            "type": "input",
+            "name": "Slider",
+            "id": "INPUT_PLACEHOLDER",
+            "hidden": false,
+            "minHeight": 1,
+            "minWidth": 2,
+            "layout": {
+                "x": 0,
+                "y": 0,
+                "h": 2,
+                "w": 2,
+                "minH": 1,
+                "minW": 2,
+                "i": "INPUT_PLACEHOLDER"
+            }
+        }
+    ]
+}

--- a/AI_ML/IMAGE_CAPTIONING/NLP_CONNECT_VIT_GPT2/example.md
+++ b/AI_ML/IMAGE_CAPTIONING/NLP_CONNECT_VIT_GPT2/example.md
@@ -1,0 +1,1 @@
+In this example, the `LOCAL_FILE` node loads a local file and passes it to `NLP_CONNECT_VIT_GPT2`, which produces the appropriate image caption.

--- a/MANIFEST/nlp_connect_vit_gpt2.manifest.yaml
+++ b/MANIFEST/nlp_connect_vit_gpt2.manifest.yaml
@@ -1,0 +1,4 @@
+COMMAND:
+  - name: NLP Connect ViT GPT2
+    key: NLP_CONNECT_VIT_GPT2
+    type: IMAGE_CAPTION


### PR DESCRIPTION
### Description

This node calls the nlp-connect ViT GPT2 model for image captioning on an input image, and produces a Dataframe with a "caption" column containing the output. 

P.S: Do Datacontainers support plain python dictionaries?

- [X] I've included a concise description of what each node does

### Styleguide

- [X] My node adheres to the [styleguide](https://github.com/flojoy-io/nodes/blob/main/node_styleguide.md) for Flojoy nodes

### Docs

- [ ] I've submitted a PR for a documentation page for the new node(s) that contains usage examples (see docs.flojoy.io)


## NOTE
This PR is dependent on the merge and push of [this PR](https://github.com/flojoy-io/python/pull/41)

