### PR TITLE
Fixed a bug in CI workflow

### DIFF
--- a/.github/workflows/create-studio-docs-pr.yml
+++ b/.github/workflows/create-studio-docs-pr.yml
@@ -38,12 +38,20 @@ jobs:
           token: ${{ steps.generate_token.outputs.token }}
       
       - name: Get last commit message
-        if: github.event.pull_request.merged == false
+        if: github.event.pull_request.merged != true
         run: |
           cd ${{ github.workspace }}
           git fetch origin ${{ github.head_ref }}
           git checkout ${{ github.head_ref }}
-          echo "LAST_COMMIT_MSG=$(git log -1 --pretty=format:'%s' '${{ github.event.pull_request.head.sha }}' )" >> "$GITHUB_ENV"
+          echo "LAST_COMMIT_MSG=$(git log -1 --pretty=format:'%s')" >> "$GITHUB_ENV"
+
+      - name: Get last commit message
+        if: github.event.pull_request.merged == true
+        run: |
+          cd ${{ github.workspace }}
+          git fetch origin main
+          git checkout main
+          echo "LAST_COMMIT_MSG=$(git log -1 --pretty=format:'%s')" >> "$GITHUB_ENV"
 
       - name: Send pull-request
         env:

--- a/.github/workflows/create-studio-docs-pr.yml
+++ b/.github/workflows/create-studio-docs-pr.yml
@@ -38,6 +38,7 @@ jobs:
           token: ${{ steps.generate_token.outputs.token }}
       
       - name: Get last commit message
+        if: github.event.pull_request.merged == false
         run: |
           cd ${{ github.workspace }}
           git fetch origin ${{ github.head_ref }}

--- a/create_pr
+++ b/create_pr
@@ -34,7 +34,7 @@ if git branch -a | grep -q $DOC_BRANCH; then
   if git status --porcelain | grep -q .; then
     echo "There are changes in the branch."
     git add .
-    git commit -m "$LAST_COMMIT_MSG"
+    git commit -m "update: $LAST_COMMIT_MSG"
     git push origin $DOC_BRANCH
     if [ "$IS_MERGED" = true ]; then
       gh pr ready
@@ -47,7 +47,7 @@ else
   cd $DOC_FOLDER
   if git status --porcelain | grep -q .; then
     git add .
-    git commit -m "$LAST_COMMIT_MSG"
+    git commit -m "update: $LAST_COMMIT_MSG"
     git push -u origin $DOC_BRANCH --force
     gh pr create \
       --body "corresponding PR in nodes: https://github.com/flojoy-io/nodes/pull/$PR_NUM" \
@@ -76,7 +76,7 @@ if git branch -a | grep -q $STUDIO_BRANCH; then
     if git status --porcelain | grep -q .; then
       echo "There are changes in the branch."
       git add .
-      git commit -m "$LAST_COMMIT_MSG"
+      git commit -m "update: $LAST_COMMIT_MSG"
       git push origin $STUDIO_BRANCH
       gh pr ready
     fi
@@ -87,7 +87,7 @@ if git branch -a | grep -q $STUDIO_BRANCH; then
     if git status --porcelain | grep -q .; then
       echo "There are changes in the branch."
       git add .
-      git commit -m "$LAST_COMMIT_MSG"
+      git commit -m "update: $LAST_COMMIT_MSG"
       git push origin $STUDIO_BRANCH
     fi
   fi
@@ -103,7 +103,7 @@ else
   cd ../../
   if git status --porcelain | grep -q .; then
     git add .
-    git commit -m "$LAST_COMMIT_MSG"
+    git commit -m "update: $LAST_COMMIT_MSG"
     git push -u origin $STUDIO_BRANCH --force
     gh pr create \
       --body "corresponding PR in nodes: https://github.com/flojoy-io/nodes/pull/$PR_NUM" \


### PR DESCRIPTION
- Fixed a bug in Get last commit message step on PR closed event.

## Changes:
- I have added a condition for the first "Get Last Commit Message" step to check if the pull request is not merged. So it will checkout to the branch where PR was created and get the commit message from the last commit.
- I have added another step for getting last commit message when PR is merged. So it'll checkout to main branch and retrieve the commit message from last commit made on main branch.
- Updated create pr script to not throw error if last commit message is an empty string.

## Testing
- The changes appear to be theoretically correct since [this](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution#example-only-run-job-for-specific-repository) document suggests the possibility of controlling job execution based on a condition.