### PR TITLE
remove deprecated req

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,6 @@ scikit-image==0.20.0
 scikit-learn==1.2.2
 scipy==1.10.1
 six==1.16.0
-sklearn==0.0.post5
 threadpoolctl==3.1.0
 ticlib==0.2.2
 tifffile==2023.4.12


### PR DESCRIPTION
Drop an old requirement that is breaking ci/cd

### Description

- [ ] I've included a concise description of what each node does

### Styleguide

- [ ] My node adheres to the [styleguide](https://github.com/flojoy-io/nodes/blob/main/node_styleguide.md) for Flojoy nodes

### Docs

- [ ] I've submitted a PR for a documentation page for the new node(s) that contains usage examples (see docs.flojoy.io)

### Testing

To test I made a virtual env and pip installed everything
```
scorinaldi@donae2:~/projects/flowjoi/nodes$ mkvirtualenv fj_throw
created virtual environment CPython3.10.6.final.0-64 in 385ms
  creator CPython3Posix(dest=/home/scorinaldi/.virtualenvs/fj_throw, clear=False, no_vcs_ignore=False, global=False)
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/home/scorinaldi/.local/share/virtualenv)
    added seed packages: pip==23.1.2, setuptools==67.8.0, wheel==0.40.0
  activators BashActivator,CShellActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator
virtualenvwrapper.user_scripts creating /home/scorinaldi/.virtualenvs/fj_throw/bin/predeactivate
virtualenvwrapper.user_scripts creating /home/scorinaldi/.virtualenvs/fj_throw/bin/postdeactivate
virtualenvwrapper.user_scripts creating /home/scorinaldi/.virtualenvs/fj_throw/bin/preactivate
virtualenvwrapper.user_scripts creating /home/scorinaldi/.virtualenvs/fj_throw/bin/postactivate
virtualenvwrapper.user_scripts creating /home/scorinaldi/.virtualenvs/fj_throw/bin/get_env_details
(fj_throw) scorinaldi@donae2:~/projects/flowjoi/nodes$ pip install -r requirements.txt 
Collecting black==23.3.0 (from -r requirements.txt (line 1))
  Using cached black-23.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.7 MB)
Collecting click==8.1.3 (from -r requirements.txt (line 2))
  Using cached click-8.1.3-py3-none-any.whl (96 kB)
Collecting cmdstanpy==1.1.0 (from -r requirements.txt (line 3))
...
Installing collected packages: pytz, pyserial, PyMeeus, Phidget22, LabJackPython, ephem, xlrd, tzdata, tqdm, tomli, ticlib, threadpoolctl, six, PyYAML, pyparsing, platformdirs, Pillow, pathspec, packaging, numpy, networkx, mypy-extensions, lxml, lazy_loader, kiwisolver, joblib, importlib-resources, fonttools, cycler, convertdate, click, tifffile, scipy, PyWavelets, python-dateutil, opencv-python-headless, imageio, contourpy, black, scikit-learn, scikit-image, pandas, matplotlib, LunarCalendar, holidays, rdatasets, cmdstanpy, prophet
Successfully installed LabJackPython-2.1.0 LunarCalendar-0.0.9 Phidget22-1.15.20230608 Pillow-9.5.0 PyMeeus-0.5.12 PyWavelets-1.4.1 PyYAML-6.0 black-23.3.0 click-8.1.3 cmdstanpy-1.1.0 contourpy-1.1.0 convertdate-2.4.0 cycler-0.11.0 ephem-4.1.4 fonttools-4.40.0 holidays-0.26 imageio-2.31.1 importlib-resources-5.12.0 joblib-1.2.0 kiwisolver-1.4.4 lazy_loader-0.2 lxml-4.9.2 matplotlib-3.7.1 mypy-extensions-1.0.0 networkx-3.1 numpy-1.24.3 opencv-python-headless-4.7.0.72 packaging-23.1 pandas-2.0.2 pathspec-0.11.1 platformdirs-3.5.3 prophet-1.1.4 pyparsing-3.0.9 pyserial-3.5 python-dateutil-2.8.2 pytz-2023.3 rdatasets-0.1.0 scikit-image-0.20.0 scikit-learn-1.2.2 scipy-1.10.1 six-1.16.0 threadpoolctl-3.1.0 ticlib-0.2.2 tifffile-2023.4.12 tomli-2.0.1 tqdm-4.65.0 tzdata-2023.3 xlrd-2.0.1
(fj_throw) scorinaldi@donae2:~/projects/flowjoi/nodes$
```
Then i noted that it fixes the build issue:
https://github.com/flojoy-io/nodes/actions/runs/5346930876/jobs/9694651518?pr=131