### PR TITLE
`Count Vectorizer` key should match name of function class

### DIFF
--- a/MANIFEST/countvec.manifest.yaml
+++ b/MANIFEST/countvec.manifest.yaml
@@ -1,6 +1,6 @@
 COMMAND:
   - name: CountVectorizer
-    key: COUNTVECTORIZER
+    key: COUNT_VECTORIZER
     type: NLP
     pip_dependencies:
       - name: scikit-learn


### PR DESCRIPTION
Fixing an error in the named manifest file
### Description

- [ ] I've included a concise description of what each node does

### Styleguide

- [ ] My node adheres to the [styleguide](https://github.com/flojoy-io/nodes/blob/main/node_styleguide.md) for Flojoy nodes

### Docs

- [ ] I've submitted a PR for a documentation page for the new node(s) that contains usage examples (see docs.flojoy.io)

### Testing

- [ ] This PR includes a unit test ([example here](https://github.com/flojoy-io/nodes/blob/c28808f2d0aec8f116cdb3fccb46c4f5256574e9/TRANSFORMERS/ARITHMETIC/ADD/ADD_test_.py) and/or ideally a screenshot of the node's output on an example app.
