### PR TITLE
Inclusion of scalar data type to arthimatic nodes

### DIFF
--- a/TRANSFORMERS/ARITHMETIC/ABS/ABS.py
+++ b/TRANSFORMERS/ARITHMETIC/ABS/ABS.py
@@ -23,7 +23,7 @@ def ABS(dc_inputs: list[DataContainer], params: dict) -> DataContainer:
 
     match dc_inputs[0].type:
         case "scalar":
-            return DataContainer(type='scalar', c=np.abs(dc_inputs[0].c))
+            return DataContainer(type="scalar", c=np.abs(dc_inputs[0].c))
 
         case "ordered_pair":
             return DataContainer(x=dc_inputs[0].x, y=np.abs(dc_inputs[0].y))

--- a/TRANSFORMERS/ARITHMETIC/ABS/ABS.py
+++ b/TRANSFORMERS/ARITHMETIC/ABS/ABS.py
@@ -4,5 +4,26 @@ from flojoy import flojoy, DataContainer
 
 @flojoy
 def ABS(dc_inputs: list[DataContainer], params: dict) -> DataContainer:
-    """Returns abolute value"""
-    return DataContainer(x=dc_inputs[0].y, y=np.abs(dc_inputs[0].y))
+    """The ABS node returns the absolute value for the input.
+    The node can handle scalar and ordered pair inputs currently
+
+    TODO - reconcile.py so matrix and dataframe types can be handled.
+
+    Parameters
+    ----------
+    None
+
+    Returns:
+    --------
+    DataContainer:
+        type 'ordered pair' if 'ordered pair' is input.
+
+        type 'scalar' if 'scalar' is input.
+    """
+
+    match dc_inputs[0].type:
+        case "scalar":
+            return DataContainer(type='scalar', c=np.abs(dc_inputs[0].c))
+
+        case "ordered_pair":
+            return DataContainer(x=dc_inputs[0].x, y=np.abs(dc_inputs[0].y))

--- a/TRANSFORMERS/ARITHMETIC/ABS/ABS_test_.py
+++ b/TRANSFORMERS/ARITHMETIC/ABS/ABS_test_.py
@@ -22,21 +22,16 @@ def mock_flojoy_decorator(f):
 patch("flojoy.flojoy", mock_flojoy_decorator).start()
 
 # After Patching the flojoy decorator, let's load the node under test.
-import ADD
+import ABS
 
 
-def test_ADD():
+def test_ABS():
     # create the two ordered pair datacontainers
-    element_a = DataContainer(
-        type="ordered_pair", x=numpy.linspace(-10, 10, 100), y=[10] * 100
-    )
-
-    element_b = DataContainer(type="scalar", c=10)
+    element_a = DataContainer(type="scalar", c=-10)
 
     # node under test
-    res = ADD.ADD([element_a, element_b], {})
+    res = ABS.ABS([element_a], {})
 
     # check that the correct number of elements
-    assert (len(res.y)) == 100
-    for y in res.y:
-        assert y == 20
+    for c in res.c:
+        assert c == 10

--- a/TRANSFORMERS/ARITHMETIC/ADD/ADD.py
+++ b/TRANSFORMERS/ARITHMETIC/ADD/ADD.py
@@ -27,9 +27,7 @@ def ADD(dc_inputs: list[DataContainer], params: dict) -> DataContainer:
         )
     match [dc_inputs[0].type, dc_inputs[1].type]:
         case ["scalar", "ordered_pair"]:
-            raise ValueError(
-                "The 'scalar' type should be connect to the 'y' input."
-            )
+            raise ValueError("The 'scalar' type should be connect to the 'y' input.")
 
         case ["ordered_pair", "ordered_pair"]:
             a = dc_inputs[0].y

--- a/TRANSFORMERS/ARITHMETIC/ADD/ADD.py
+++ b/TRANSFORMERS/ARITHMETIC/ADD/ADD.py
@@ -4,21 +4,55 @@ from flojoy import flojoy, DataContainer
 
 @flojoy
 def ADD(dc_inputs: list[DataContainer], params: dict) -> DataContainer:
-    """Add 2 or more numeric arrays, matrices, dataframes, or constants element-wise.
-    When a constant is added to an array or matrix, each element in the array or
-    matrix will be increased by the constant value. If 2 arrays or matrices of different
-    sizes are added, the output will be the size of the larger array or matrix with
-    only the overlapping elements changed.
+    """The ADD node adds the values from the two inputs.
+    The node can handle scalar and ordered pair inputs currently
+
+    TODO - reconcile.py so matrix and dataframe types can be handled.
+
+    Parameters
+    ----------
+    None
+
+    Returns:
+    --------
+    DataContainer:
+        type 'ordered pair' if one 'ordered pair' is input.
+
+        type 'scalar' if two 'scalars' are input.
     """
 
     if len(dc_inputs) < 2:
         raise ValueError(
             f"To add the values, ADD node requires two inputs, {len(dc_inputs)} was given!"
         )
-    a = dc_inputs[0].y
-    b = dc_inputs[1].y
+    match [dc_inputs[0].type, dc_inputs[1].type]:
+        case ["scalar", "ordered_pair"]:
+            raise ValueError(
+                "The 'scalar' type should be connect to the 'y' input."
+            )
 
-    x = dc_inputs[0].x
-    y = np.add(a, b)
+        case ["ordered_pair", "ordered_pair"]:
+            a = dc_inputs[0].y
+            b = dc_inputs[1].y
 
-    return DataContainer(x=x, y=y)
+            x = dc_inputs[0].x
+            y = np.add(a, b)
+
+            return DataContainer(x=x, y=y)
+
+        case ["ordered_pair", "scalar"]:
+            a = dc_inputs[0].y
+            b = dc_inputs[1].c
+
+            x = dc_inputs[0].x
+            y = np.add(a, b)
+
+            return DataContainer(x=x, y=y)
+
+        case ["scalar", "scalar"]:
+            a = dc_inputs[0].c
+            b = dc_inputs[1].c
+
+            c = np.add(a, b)
+
+            return DataContainer(type="scalar", c=c)

--- a/TRANSFORMERS/ARITHMETIC/DIVIDE/DIVIDE.py
+++ b/TRANSFORMERS/ARITHMETIC/DIVIDE/DIVIDE.py
@@ -27,9 +27,7 @@ def DIVIDE(dc_inputs: list[DataContainer], params: dict) -> DataContainer:
         )
     match [dc_inputs[0].type, dc_inputs[1].type]:
         case ["scalar", "ordered_pair"]:
-            raise ValueError(
-                "The 'scalar' type should be connect to the 'y' input."
-            )
+            raise ValueError("The 'scalar' type should be connect to the 'y' input.")
 
         case ["ordered_pair", "ordered_pair"]:
             a = dc_inputs[0].y

--- a/TRANSFORMERS/ARITHMETIC/DIVIDE/DIVIDE.py
+++ b/TRANSFORMERS/ARITHMETIC/DIVIDE/DIVIDE.py
@@ -4,19 +4,55 @@ from flojoy import flojoy, DataContainer
 
 @flojoy
 def DIVIDE(dc_inputs: list[DataContainer], params: dict) -> DataContainer:
-    """Divide 2 or more numeric arrays, matrices, dataframes, or constants element-wise.
-    When a constant is added to an array or matrix, each element in the array or
-    matrix will be increased by the constant value.
+    """The DIVIDE node divides the values from the two inputs.
+    The node can handle scalar and ordered pair inputs currently
+
+    TODO - reconcile.py so matrix and dataframe types can be handled.
+
+    Parameters
+    ----------
+    None
+
+    Returns:
+    --------
+    DataContainer:
+        type 'ordered pair' if one 'ordered pair' is input.
+
+        type 'scalar' if two 'scalars' are input.
     """
 
     if len(dc_inputs) < 2:
         raise ValueError(
-            f"To add the values, DIVIDE node requires two inputs, {len(dc_inputs)} was given!"
+            f"To divide the values, DIVIDE node requires two inputs, {len(dc_inputs)} was given!"
         )
-    a = dc_inputs[0].y
-    b = dc_inputs[1].y
+    match [dc_inputs[0].type, dc_inputs[1].type]:
+        case ["scalar", "ordered_pair"]:
+            raise ValueError(
+                "The 'scalar' type should be connect to the 'y' input."
+            )
 
-    x = dc_inputs[0].x
-    y = np.divide(a, b)
+        case ["ordered_pair", "ordered_pair"]:
+            a = dc_inputs[0].y
+            b = dc_inputs[1].y
 
-    return DataContainer(x=x, y=y)
+            x = dc_inputs[0].x
+            y = np.divide(a, b)
+
+            return DataContainer(x=x, y=y)
+
+        case ["ordered_pair", "scalar"]:
+            a = dc_inputs[0].y
+            b = dc_inputs[1].c
+
+            x = dc_inputs[0].x
+            y = np.divide(a, b)
+
+            return DataContainer(x=x, y=y)
+
+        case ["scalar", "scalar"]:
+            a = dc_inputs[0].c
+            b = dc_inputs[1].c
+
+            c = np.divide(a, b)
+
+            return DataContainer(type="scalar", c=c)

--- a/TRANSFORMERS/ARITHMETIC/DIVIDE/DIVIDE_test_.py
+++ b/TRANSFORMERS/ARITHMETIC/DIVIDE/DIVIDE_test_.py
@@ -31,9 +31,7 @@ def test_DIVIDE():
         type="ordered_pair", x=numpy.linspace(-10, 10, 100), y=[10] * 100
     )
 
-    element_b = DataContainer(
-        type="ordered_pair", x=numpy.linspace(-10, 10, 100), y=[7] * 100
-    )
+    element_b = DataContainer(type="scalar", c=10.0)
 
     # node under test
     res = DIVIDE.DIVIDE([element_a, element_b], {})
@@ -41,4 +39,4 @@ def test_DIVIDE():
     # check that the correct number of elements
     assert (len(res.y)) == 100
     for y in res.y:
-        assert y == 10.0 / 7.0
+        assert y == 10.0 / 10.0

--- a/TRANSFORMERS/ARITHMETIC/MULTIPLY/MULTIPLY.py
+++ b/TRANSFORMERS/ARITHMETIC/MULTIPLY/MULTIPLY.py
@@ -27,9 +27,7 @@ def MULTIPLY(dc_inputs: list[DataContainer], params: dict) -> DataContainer:
         )
     match [dc_inputs[0].type, dc_inputs[1].type]:
         case ["scalar", "ordered_pair"]:
-            raise ValueError(
-                "The 'scalar' type should be connect to the 'y' input."
-            )
+            raise ValueError("The 'scalar' type should be connect to the 'y' input.")
 
         case ["ordered_pair", "ordered_pair"]:
             a = dc_inputs[0].y
@@ -56,4 +54,3 @@ def MULTIPLY(dc_inputs: list[DataContainer], params: dict) -> DataContainer:
             c = np.multiply(a, b)
 
             return DataContainer(type="scalar", c=c)
-

--- a/TRANSFORMERS/ARITHMETIC/MULTIPLY/MULTIPLY.py
+++ b/TRANSFORMERS/ARITHMETIC/MULTIPLY/MULTIPLY.py
@@ -4,11 +4,56 @@ from flojoy import flojoy, DataContainer
 
 @flojoy
 def MULTIPLY(dc_inputs: list[DataContainer], params: dict) -> DataContainer:
-    """Takes 2 input vectors, multiplies them, and returns the result"""
-    a = dc_inputs[0].y
-    b = dc_inputs[1].y
+    """The MULTIPLY node multiplies the values from the two inputs.
+    The node can handle scalar and ordered pair inputs currently
 
-    x = dc_inputs[0].x
-    y = np.multiply(a, b)
+    TODO - reconcile.py so matrix and dataframe types can be handled.
 
-    return DataContainer(x=x, y=y)
+    Parameters
+    ----------
+    None
+
+    Returns:
+    --------
+    DataContainer:
+        type 'ordered pair' if one 'ordered pair' is input.
+
+        type 'scalar' if two 'scalars' are input.
+    """
+
+    if len(dc_inputs) < 2:
+        raise ValueError(
+            f"To multiply the values, MULTIPLY node requires two inputs, {len(dc_inputs)} was given!"
+        )
+    match [dc_inputs[0].type, dc_inputs[1].type]:
+        case ["scalar", "ordered_pair"]:
+            raise ValueError(
+                "The 'scalar' type should be connect to the 'y' input."
+            )
+
+        case ["ordered_pair", "ordered_pair"]:
+            a = dc_inputs[0].y
+            b = dc_inputs[1].y
+
+            x = dc_inputs[0].x
+            y = np.multiply(a, b)
+
+            return DataContainer(x=x, y=y)
+
+        case ["ordered_pair", "scalar"]:
+            a = dc_inputs[0].y
+            b = dc_inputs[1].c
+
+            x = dc_inputs[0].x
+            y = np.multiply(a, b)
+
+            return DataContainer(x=x, y=y)
+
+        case ["scalar", "scalar"]:
+            a = dc_inputs[0].c
+            b = dc_inputs[1].c
+
+            c = np.multiply(a, b)
+
+            return DataContainer(type="scalar", c=c)
+

--- a/TRANSFORMERS/ARITHMETIC/MULTIPLY/MULTIPLY_test_.py
+++ b/TRANSFORMERS/ARITHMETIC/MULTIPLY/MULTIPLY_test_.py
@@ -22,10 +22,10 @@ def mock_flojoy_decorator(f):
 patch("flojoy.flojoy", mock_flojoy_decorator).start()
 
 # After Patching the flojoy decorator, let's load the node under test.
-import ADD
+import MULTIPLY
 
 
-def test_ADD():
+def test_MULTIPLY():
     # create the two ordered pair datacontainers
     element_a = DataContainer(
         type="ordered_pair", x=numpy.linspace(-10, 10, 100), y=[10] * 100
@@ -34,9 +34,9 @@ def test_ADD():
     element_b = DataContainer(type="scalar", c=10)
 
     # node under test
-    res = ADD.ADD([element_a, element_b], {})
+    res = MULTIPLY.MULTIPLY([element_a, element_b], {})
 
     # check that the correct number of elements
     assert (len(res.y)) == 100
     for y in res.y:
-        assert y == 20
+        assert y == 100

--- a/TRANSFORMERS/ARITHMETIC/SUBTRACT/SUBTRACT.py
+++ b/TRANSFORMERS/ARITHMETIC/SUBTRACT/SUBTRACT.py
@@ -4,16 +4,55 @@ from flojoy import flojoy, DataContainer
 
 @flojoy
 def SUBTRACT(dc_inputs: list[DataContainer], params: dict) -> DataContainer:
-    """Subtract 2 input vectors and return the result"""
+    """The SUBTRACT node subtracts the values from the two inputs.
+    The node can handle scalar and ordered pair inputs currently
+
+    TODO - reconcile.py so matrix and dataframe types can be handled.
+
+    Parameters
+    ----------
+    None
+
+    Returns:
+    --------
+    DataContainer:
+        type 'ordered pair' if one 'ordered pair' is input.
+
+        type 'scalar' if two 'scalars' are input.
+    """
 
     if len(dc_inputs) < 2:
         raise ValueError(
-            f"To substract the values, SUBSTRACT node requires two inputs, {len(dc_inputs)} was given!"
+            f"To subtract the values, SUBTRACT node requires two inputs, {len(dc_inputs)} was given!"
         )
-    a = dc_inputs[0].y
-    b = dc_inputs[1].y
+    match [dc_inputs[0].type, dc_inputs[1].type]:
+        case ["scalar", "ordered_pair"]:
+            raise ValueError(
+                "The 'scalar' type should be connect to the 'y' input."
+            )
 
-    x = dc_inputs[0].x
-    y = np.subtract(a, b)
+        case ["ordered_pair", "ordered_pair"]:
+            a = dc_inputs[0].y
+            b = dc_inputs[1].y
 
-    return DataContainer(x=x, y=y)
+            x = dc_inputs[0].x
+            y = np.subtract(a, b)
+
+            return DataContainer(x=x, y=y)
+
+        case ["ordered_pair", "scalar"]:
+            a = dc_inputs[0].y
+            b = dc_inputs[1].c
+
+            x = dc_inputs[0].x
+            y = np.subtract(a, b)
+
+            return DataContainer(x=x, y=y)
+
+        case ["scalar", "scalar"]:
+            a = dc_inputs[0].c
+            b = dc_inputs[1].c
+
+            c = np.subtract(a, b)
+
+            return DataContainer(type="scalar", c=c)

--- a/TRANSFORMERS/ARITHMETIC/SUBTRACT/SUBTRACT.py
+++ b/TRANSFORMERS/ARITHMETIC/SUBTRACT/SUBTRACT.py
@@ -27,9 +27,7 @@ def SUBTRACT(dc_inputs: list[DataContainer], params: dict) -> DataContainer:
         )
     match [dc_inputs[0].type, dc_inputs[1].type]:
         case ["scalar", "ordered_pair"]:
-            raise ValueError(
-                "The 'scalar' type should be connect to the 'y' input."
-            )
+            raise ValueError("The 'scalar' type should be connect to the 'y' input.")
 
         case ["ordered_pair", "ordered_pair"]:
             a = dc_inputs[0].y

--- a/TRANSFORMERS/ARITHMETIC/SUBTRACT/SUBTRACT_test_.py
+++ b/TRANSFORMERS/ARITHMETIC/SUBTRACT/SUBTRACT_test_.py
@@ -22,21 +22,21 @@ def mock_flojoy_decorator(f):
 patch("flojoy.flojoy", mock_flojoy_decorator).start()
 
 # After Patching the flojoy decorator, let's load the node under test.
-import ADD
+import SUBTRACT
 
 
-def test_ADD():
+def test_SUBTRACT():
     # create the two ordered pair datacontainers
     element_a = DataContainer(
-        type="ordered_pair", x=numpy.linspace(-10, 10, 100), y=[10] * 100
+        type="ordered_pair", x=numpy.linspace(-10, 10, 100), y=[11] * 100
     )
 
     element_b = DataContainer(type="scalar", c=10)
 
     # node under test
-    res = ADD.ADD([element_a, element_b], {})
+    res = SUBTRACT.SUBTRACT([element_a, element_b], {})
 
     # check that the correct number of elements
     assert (len(res.y)) == 100
     for y in res.y:
-        assert y == 20
+        assert y == 1


### PR DESCRIPTION
### Description

- [x] I've included a concise description of what each node does

### Styleguide

- [x] My node adheres to the [styleguide](https://github.com/flojoy-io/nodes/blob/main/node_styleguide.md) for Flojoy nodes

### Docs

- [x] I've submitted a PR for a documentation page for the new node(s) that contains usage examples (see docs.flojoy.io)

### Testing

- [x] This PR includes a unit test ([example here](https://github.com/flojoy-io/nodes/blob/c28808f2d0aec8f116cdb3fccb46c4f5256574e9/TRANSFORMERS/ARITHMETIC/ADD/ADD_test_.py) and/or ideally a screenshot of the node's output on an example app.
