### PR TITLE
Move `NL_CONNECT_VIT_GPT2` out of `flojoy.hflib`

### DIFF
--- a/AI_ML/IMAGE_CAPTIONING/NLP_CONNECT_VIT_GPT2/NLP_CONNECT_VIT_GPT2.py
+++ b/AI_ML/IMAGE_CAPTIONING/NLP_CONNECT_VIT_GPT2/NLP_CONNECT_VIT_GPT2.py
@@ -1,12 +1,20 @@
-from flojoy import flojoy, DataFrame, Image
-from flojoy.hflib.hub_models import HubModelFactory, ImageCaptionModels
+from flojoy import (
+    flojoy,
+    run_in_venv,
+    DataFrame,
+    Image
+)
 
-import torchvision.transforms.functional as TF
 import numpy as np
 import pandas as pd
 
 
 @flojoy
+@run_in_venv(pip_dependencies=[
+    "transformers==4.30.2",
+    "torch==1.13.0",
+    "torchvision==0.14.0",
+])
 def NLP_CONNECT_VIT_GPT2(default: Image) -> DataFrame:
     """The NLP_CONNECT_VIT_GPT2 node captions an input image and produces an output string wrapped
     in a dataframe.
@@ -17,22 +25,34 @@ def NLP_CONNECT_VIT_GPT2(default: Image) -> DataFrame:
 
     Returns:
     --------
-    DataContainer:
+    DataFrame:
         DataFrame containing the caption column, and a single row.
-
     """
+
+    import transformers
+    import torchvision.transforms.functional as TF
+    from flojoy import snapshot_download 
+
     r, g, b, a = default.r, default.g, default.b, default.a
     nparray = (
         np.stack((r, g, b, a), axis=2) if a is not None else np.stack((r, g, b), axis=2)
     )
     image = TF.to_pil_image(nparray).convert("RGB")
 
-    hub_model = HubModelFactory.create_model(ImageCaptionModels.NLP_CONNECT_VIT_GPT2)
-    hub_model.download_and_cache()
-    model, feature_extractor, tokenizer = hub_model.get_executable_model()
-    pixel_values = feature_extractor(images=[image], return_tensors="pt").pixel_values
-    output_ids = model.generate(pixel_values, max_length=16, num_beams=4)
-    preds = tokenizer.batch_decode(output_ids, skip_special_tokens=True)
+    # Download repo to local flojoy cache
+    local_repo_path = snapshot_download(
+        repo_id="nlpconnect/vit-gpt2-image-captioning",
+        revision= "dc68f91c06a1ba6f15268e5b9c13ae7a7c514084",
+        local_dir_use_symlinks=False
+    )
+    # Load model objects
+    model = transformers.VisionEncoderDecoderModel.from_pretrained(local_repo_path)
+    feature_extractor = transformers.ViTImageProcessor.from_pretrained(local_repo_path)
+    tokenizer = transformers.AutoTokenizer.from_pretrained(local_repo_path)
+
+    pixel_values = feature_extractor(images=[image], return_tensors="pt").pixel_values # type: ignore
+    output_ids = model.generate(pixel_values, max_length=16, num_beams=4) # type: ignore
+    preds = tokenizer.batch_decode(output_ids, skip_special_tokens=True) # type: ignore
     pred = preds[0].strip()
 
     df_pred = pd.DataFrame.from_records([(pred,)], columns=["caption"])

--- a/AI_ML/IMAGE_CAPTIONING/NLP_CONNECT_VIT_GPT2/NLP_CONNECT_VIT_GPT2_test_.py
+++ b/AI_ML/IMAGE_CAPTIONING/NLP_CONNECT_VIT_GPT2/NLP_CONNECT_VIT_GPT2_test_.py
@@ -1,0 +1,37 @@
+import os
+import pytest
+from unittest.mock import patch
+
+import PIL.Image
+import numpy as np
+
+from flojoy import Image, DataFrame
+
+
+@pytest.fixture(scope="module")
+def mock_flojoy_decorator():
+    with patch("flojoy.flojoy", lambda x: x) as mock_flojoy:
+        yield mock_flojoy
+
+
+@pytest.fixture
+def obama_image_array_rgb():
+    _image_path = (
+        f"{os.path.dirname(os.path.realpath(__file__))}/assets/President_Barack_Obama.jpg"
+    )
+    image = PIL.Image.open(_image_path).convert("RGB")
+    return np.array(image)
+
+
+
+def test_NLP_CONNECT_VIT_GPT2(mock_flojoy_decorator, obama_image_array_rgb):
+    import NLP_CONNECT_VIT_GPT2
+
+    input_img = Image(
+        r=obama_image_array_rgb[:, :, 0],
+        g=obama_image_array_rgb[:, :, 1],
+        b=obama_image_array_rgb[:, :, 2],
+        a=None,
+    )
+    output_df = NLP_CONNECT_VIT_GPT2.NLP_CONNECT_VIT_GPT2(input_img) # type: ignore
+    assert output_df.m.iloc[0].caption == "a man in a suit and tie standing in front of a flag"

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,4 +47,4 @@ tqdm==4.65.0
 tzdata==2023.3
 xlrd==2.0.1
 pytest==7.1.3
-flojoy==0.1.5.dev3
+flojoy==0.1.5.dev10


### PR DESCRIPTION
### Description

- [X] I've included a concise description of what each node does

### Styleguide

- [X] My node adheres to the [styleguide](https://github.com/flojoy-io/nodes/blob/main/node_styleguide.md) for Flojoy nodes

### Docs

- [ ] I've submitted a PR for a documentation page for the new node(s) that contains usage examples (see docs.flojoy.io)

### Testing

- [X] This PR includes a unit test ([example here](https://github.com/flojoy-io/nodes/blob/c28808f2d0aec8f116cdb3fccb46c4f5256574e9/TRANSFORMERS/ARITHMETIC/ADD/ADD_test_.py) and/or ideally a screenshot of the node's output on an example app.
