### PR TITLE
Fix edge case handling for `SCIPY/STATS/TMIN` and `SCIPY/STATS/TMAX`

### DIFF
--- a/NUMPY/LINALG/CHOLESKY/CHOLESKY.py
+++ b/NUMPY/LINALG/CHOLESKY/CHOLESKY.py
@@ -42,7 +42,10 @@ def CHOLESKY(
 
     if isinstance(result, np.ndarray):
         result = Matrix(m=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/NUMPY/LINALG/DET/DET.py
+++ b/NUMPY/LINALG/DET/DET.py
@@ -33,7 +33,10 @@ def DET(
 
     if isinstance(result, np.ndarray):
         result = Matrix(m=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/NUMPY/LINALG/EIG/EIG.py
+++ b/NUMPY/LINALG/EIG/EIG.py
@@ -49,7 +49,10 @@ def EIG(
 
     if isinstance(result, np.ndarray):
         result = Matrix(m=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/NUMPY/LINALG/EIGH/EIGH.py
+++ b/NUMPY/LINALG/EIGH/EIGH.py
@@ -43,7 +43,10 @@ def EIGH(
 
     if isinstance(result, np.ndarray):
         result = Matrix(m=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/NUMPY/LINALG/EIGVALS/EIGVALS.py
+++ b/NUMPY/LINALG/EIGVALS/EIGVALS.py
@@ -36,7 +36,10 @@ def EIGVALS(
 
     if isinstance(result, np.ndarray):
         result = Matrix(m=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/NUMPY/LINALG/EIGVALSH/EIGVALSH.py
+++ b/NUMPY/LINALG/EIGVALSH/EIGVALSH.py
@@ -45,7 +45,10 @@ def EIGVALSH(
 
     if isinstance(result, np.ndarray):
         result = Matrix(m=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/NUMPY/LINALG/INV/INV.py
+++ b/NUMPY/LINALG/INV/INV.py
@@ -36,7 +36,10 @@ def INV(
 
     if isinstance(result, np.ndarray):
         result = Matrix(m=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/NUMPY/LINALG/MATRIX_POWER/MATRIX_POWER.py
+++ b/NUMPY/LINALG/MATRIX_POWER/MATRIX_POWER.py
@@ -45,7 +45,10 @@ def MATRIX_POWER(
 
     if isinstance(result, np.ndarray):
         result = Matrix(m=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/NUMPY/LINALG/PINV/PINV.py
+++ b/NUMPY/LINALG/PINV/PINV.py
@@ -55,7 +55,10 @@ def PINV(
 
     if isinstance(result, np.ndarray):
         result = Matrix(m=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/NUMPY/LINALG/QR/QR.py
+++ b/NUMPY/LINALG/QR/QR.py
@@ -72,7 +72,10 @@ def QR(
 
     if isinstance(result, np.ndarray):
         result = Matrix(m=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/NUMPY/LINALG/SLOGDET/SLOGDET.py
+++ b/NUMPY/LINALG/SLOGDET/SLOGDET.py
@@ -53,7 +53,10 @@ def SLOGDET(
 
     if isinstance(result, np.ndarray):
         result = Matrix(m=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/NUMPY/LINALG/SVD/SVD.py
+++ b/NUMPY/LINALG/SVD/SVD.py
@@ -75,7 +75,10 @@ def SVD(
 
     if isinstance(result, np.ndarray):
         result = Matrix(m=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/NUMPY/LINALG/TENSORINV/TENSORINV.py
+++ b/NUMPY/LINALG/TENSORINV/TENSORINV.py
@@ -44,7 +44,10 @@ def TENSORINV(
 
     if isinstance(result, np.ndarray):
         result = Matrix(m=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/SIGNAL/BSPLINE/BSPLINE.py
+++ b/SCIPY/SIGNAL/BSPLINE/BSPLINE.py
@@ -36,7 +36,10 @@ def BSPLINE(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/SIGNAL/CUBIC/CUBIC.py
+++ b/SCIPY/SIGNAL/CUBIC/CUBIC.py
@@ -34,7 +34,10 @@ def CUBIC(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/SIGNAL/DECIMATE/DECIMATE.py
+++ b/SCIPY/SIGNAL/DECIMATE/DECIMATE.py
@@ -65,7 +65,10 @@ def DECIMATE(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/SIGNAL/DETREND/DETREND.py
+++ b/SCIPY/SIGNAL/DETREND/DETREND.py
@@ -56,7 +56,10 @@ def DETREND(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/SIGNAL/GAUSS_SPLINE/GAUSS_SPLINE.py
+++ b/SCIPY/SIGNAL/GAUSS_SPLINE/GAUSS_SPLINE.py
@@ -36,7 +36,10 @@ def GAUSS_SPLINE(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/SIGNAL/HILBERT/HILBERT.py
+++ b/SCIPY/SIGNAL/HILBERT/HILBERT.py
@@ -43,7 +43,10 @@ def HILBERT(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/SIGNAL/KAISER_BETA/KAISER_BETA.py
+++ b/SCIPY/SIGNAL/KAISER_BETA/KAISER_BETA.py
@@ -33,7 +33,10 @@ def KAISER_BETA(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/SIGNAL/PERIODOGRAM/PERIODOGRAM.py
+++ b/SCIPY/SIGNAL/PERIODOGRAM/PERIODOGRAM.py
@@ -93,7 +93,10 @@ def PERIODOGRAM(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/SIGNAL/QUADRATIC/QUADRATIC.py
+++ b/SCIPY/SIGNAL/QUADRATIC/QUADRATIC.py
@@ -34,7 +34,10 @@ def QUADRATIC(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/SIGNAL/SAVGOL_FILTER/SAVGOL_FILTER.py
+++ b/SCIPY/SIGNAL/SAVGOL_FILTER/SAVGOL_FILTER.py
@@ -81,7 +81,10 @@ def SAVGOL_FILTER(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/SIGNAL/STFT/STFT.py
+++ b/SCIPY/SIGNAL/STFT/STFT.py
@@ -126,7 +126,10 @@ def STFT(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/SIGNAL/WELCH/WELCH.py
+++ b/SCIPY/SIGNAL/WELCH/WELCH.py
@@ -115,7 +115,10 @@ def WELCH(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/STATS/ANDERSON/ANDERSON.py
+++ b/SCIPY/STATS/ANDERSON/ANDERSON.py
@@ -62,7 +62,10 @@ def ANDERSON(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/STATS/BINOM_TEST/BINOM_TEST.py
+++ b/SCIPY/STATS/BINOM_TEST/BINOM_TEST.py
@@ -55,7 +55,10 @@ def BINOM_TEST(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/STATS/DESCRIBE/DESCRIBE.py
+++ b/SCIPY/STATS/DESCRIBE/DESCRIBE.py
@@ -70,7 +70,10 @@ def DESCRIBE(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/STATS/GSTD/GSTD.py
+++ b/SCIPY/STATS/GSTD/GSTD.py
@@ -55,7 +55,10 @@ def GSTD(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/STATS/GZSCORE/GZSCORE.py
+++ b/SCIPY/STATS/GZSCORE/GZSCORE.py
@@ -60,7 +60,10 @@ def GZSCORE(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/STATS/JARQUE_BERA/JARQUE_BERA.py
+++ b/SCIPY/STATS/JARQUE_BERA/JARQUE_BERA.py
@@ -54,7 +54,10 @@ def JARQUE_BERA(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/STATS/KURTOSIS/KURTOSIS.py
+++ b/SCIPY/STATS/KURTOSIS/KURTOSIS.py
@@ -79,7 +79,10 @@ def KURTOSIS(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/STATS/KURTOSISTEST/KURTOSISTEST.py
+++ b/SCIPY/STATS/KURTOSISTEST/KURTOSISTEST.py
@@ -80,7 +80,10 @@ def KURTOSISTEST(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/STATS/MOMENT/MOMENT.py
+++ b/SCIPY/STATS/MOMENT/MOMENT.py
@@ -69,7 +69,10 @@ def MOMENT(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/STATS/NORMALTEST/NORMALTEST.py
+++ b/SCIPY/STATS/NORMALTEST/NORMALTEST.py
@@ -66,7 +66,10 @@ def NORMALTEST(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/STATS/SEM/SEM.py
+++ b/SCIPY/STATS/SEM/SEM.py
@@ -56,7 +56,10 @@ def SEM(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/STATS/SHAPIRO/SHAPIRO.py
+++ b/SCIPY/STATS/SHAPIRO/SHAPIRO.py
@@ -50,7 +50,10 @@ def SHAPIRO(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/STATS/SIGMACLIP/SIGMACLIP.py
+++ b/SCIPY/STATS/SIGMACLIP/SIGMACLIP.py
@@ -65,7 +65,10 @@ def SIGMACLIP(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/STATS/SKEW/SKEW.py
+++ b/SCIPY/STATS/SKEW/SKEW.py
@@ -71,7 +71,10 @@ def SKEW(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/STATS/SKEWTEST/SKEWTEST.py
+++ b/SCIPY/STATS/SKEWTEST/SKEWTEST.py
@@ -80,7 +80,10 @@ def SKEWTEST(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/STATS/TMAX/TMAX.py
+++ b/SCIPY/STATS/TMAX/TMAX.py
@@ -60,7 +60,10 @@ def TMAX(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/STATS/TMIN/TMIN.py
+++ b/SCIPY/STATS/TMIN/TMIN.py
@@ -61,7 +61,8 @@ def TMIN(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(result, np.number | float | int), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/STATS/TMIN/TMIN.py
+++ b/SCIPY/STATS/TMIN/TMIN.py
@@ -62,7 +62,9 @@ def TMIN(
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
     else:
-        assert isinstance(result, np.number | float | int), f"Expected np.number, float or int for result, got {type(result)}"
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/STATS/TRIM1/TRIM1.py
+++ b/SCIPY/STATS/TRIM1/TRIM1.py
@@ -51,7 +51,10 @@ def TRIM1(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/STATS/TRIMBOTH/TRIMBOTH.py
+++ b/SCIPY/STATS/TRIMBOTH/TRIMBOTH.py
@@ -48,7 +48,10 @@ def TRIMBOTH(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/STATS/TRIM_MEAN/TRIM_MEAN.py
+++ b/SCIPY/STATS/TRIM_MEAN/TRIM_MEAN.py
@@ -46,7 +46,10 @@ def TRIM_MEAN(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/STATS/TTEST_1SAMP/TTEST_1SAMP.py
+++ b/SCIPY/STATS/TTEST_1SAMP/TTEST_1SAMP.py
@@ -85,7 +85,10 @@ def TTEST_1SAMP(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/STATS/VARIATION/VARIATION.py
+++ b/SCIPY/STATS/VARIATION/VARIATION.py
@@ -79,7 +79,10 @@ def VARIATION(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/STATS/YEOJOHNSON/YEOJOHNSON.py
+++ b/SCIPY/STATS/YEOJOHNSON/YEOJOHNSON.py
@@ -38,7 +38,10 @@ def YEOJOHNSON(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result

--- a/SCIPY/STATS/ZSCORE/ZSCORE.py
+++ b/SCIPY/STATS/ZSCORE/ZSCORE.py
@@ -54,7 +54,10 @@ def ZSCORE(
 
     if isinstance(result, np.ndarray):
         result = OrderedPair(x=default.x, y=result)
-    elif isinstance(result, np.float64 | float | np.int64 | int):
+    else:
+        assert isinstance(
+            result, np.number | float | int
+        ), f"Expected np.number, float or int for result, got {type(result)}"
         result = Scalar(c=float(result))
 
     return result


### PR DESCRIPTION
The node test failed on Windows due to improper return type handling, see https://github.com/flojoy-io/nodes/actions/runs/5650629568/job/15307323474

This PR fixes the issue by checking for the `numpy.number` type.